### PR TITLE
Issue #1821902: Fixed false positives in recursive token check in _token_build_tree()

### DIFF
--- a/core/includes/token.inc
+++ b/core/includes/token.inc
@@ -609,7 +609,7 @@ function _token_build_tree($token_type, array $options, $parent_restricted = FAL
       // parent.
       $token_parents[] = $token_type;
     }
-    elseif (in_array($token, array_slice($token_parents, 1))) {
+    elseif (in_array($token, array_slice($token_parents, 1), TRUE)) {
       // Prevent duplicate recursive tokens. For example, this will prevent
       // the tree from generating the following tokens or deeper:
       // [comment:parent:parent]


### PR DESCRIPTION
Wrong upstream. Replaced by https://github.com/backdrop/backdrop/pull/4487