### PR TITLE
Issue #3192956: Fixed PHP 7.4 compatibility for the [array:value:*] token.

### DIFF
--- a/core/modules/simpletest/tests/token.test
+++ b/core/modules/simpletest/tests/token.test
@@ -950,6 +950,7 @@ class TokenArrayTestCase extends TokenTestHelper {
       'last' => 'b',
       'value:0' => 'a',
       'value:2' => 'c',
+      'value:#property' => NULL,
       'count' => 4,
       'keys' => '2, 0, 4, 1',
       'keys:value:3' => '1',

--- a/core/modules/system/system.tokens.inc
+++ b/core/modules/system/system.tokens.inc
@@ -477,7 +477,7 @@ function system_tokens($type, $tokens, array $data = array(), array $options = a
     // [array:value:*] dynamic tokens.
     if ($value_tokens = token_find_with_prefix($tokens, 'value')) {
       foreach ($value_tokens as $key => $original) {
-        if (substr($key, 0, 1) !== '#' && isset($array[$key])) {
+        if (array_key_exists($key, $array) && in_array($key, $keys)) {
           $replacements[$original] = token_render_array_value($array[$key], $options);
         }
       }


### PR DESCRIPTION
Wrong base target - replaced by https://github.com/backdrop/backdrop/pull/4494