### PR TITLE
Issue #5780: Use less-specific selectors.

### DIFF
--- a/core/themes/seven/css/seven.base.css
+++ b/core/themes/seven/css/seven.base.css
@@ -123,7 +123,6 @@ ul,
 [dir="rtl"] .item-list ul {
   margin: 0.25em 1.5em 0.25em 0;
 }
-.item-list ul li,
 li.leaf,
 ul.menu li {
   list-style-type: disc;

--- a/core/themes/seven/css/style.css
+++ b/core/themes/seven/css/style.css
@@ -22,11 +22,6 @@
 [dir="rtl"] .item-list ul {
   margin: 0.25em 1.5em 0.25em 0;
 }
-.item-list ol>li {
-  list-style-type: decimal;
-  list-style-image: none;
-}
-.item-list ul>li,
 li.leaf,
 ul.menu li {
   list-style-type: disc;


### PR DESCRIPTION
Rather than adding new more-specific selectors, this removes the unnecessary targeting selector that causes nested numeric lists to show as bullets.

<!-- Replace 'ISSUE_URL' above with the URL to the issue that this pull request
(PR) addresses. -->

<!-- Each PR must be linked to an issue on github.com/backdrop/backdrop-issues,
and most of the rationale, discussion, and explanation should take place in the
linked issue, rather than in this PR. -->

<!-- Once you have submitted your PR, wait for the automated tests to run* and
then check that they have all passed. If not, you should revise your PR until
they do. Tests will be automatically re-run* after each commit. -->

<!-- When all of the automated checks have passed, post a comment in the linked
issue stating that the PR is ready to be reviewed/tested. If you have the GitHub
privileges to do so, you can mark the issue with the labels "status - has pull
request", "PR - needs testing", and "PR - needs code review." -->

<!-- * If this PR doesn't require a test run (i.e. it just updates code
comments, adds a new GitHub action, etc.), add "[skip tests]" to the PR title.
Tests will then be skipped to save time. -->
